### PR TITLE
refactro: dump plugin off by default

### DIFF
--- a/cognite_toolkit/_builtin_modules/cdf.toml
+++ b/cognite_toolkit/_builtin_modules/cdf.toml
@@ -10,5 +10,5 @@ version = "0.0.0"
 [plugins]
 run = true
 pull = false
-dump = true
+dump = false
 


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Changelog

- [ ] Patch
- [x] Minor
- [ ] Skip

## cdf

### Changed
- Demo plugin is now off by default

## templates

No changes.
